### PR TITLE
Added SetFormValue for custom values in the HTMLRequest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Oskang09/gotenberg-go-client/v7
+module github.com/wcewong/gotenberg-go-client/v7
 
 go 1.13
 

--- a/html.go
+++ b/html.go
@@ -42,3 +42,23 @@ func (req *HTMLRequest) formFiles() map[string]Document {
 var (
 	_ = Request(new(HTMLRequest))
 )
+
+// SetFormValue sets a custom form value for the HTMLRequest.
+// This method allows you to add or modify form values that are sent to the Gotenberg API.
+// For example, you can use this to set margins (e.g., "marginTop", "marginBottom") or other
+// configuration options supported by the Gotenberg API.
+//
+// Parameters:
+//   - key: The form field key (e.g., "marginTop", "marginBottom").
+//   - value: The value to set for the form field (e.g., "0", "10mm").
+//
+// Example:
+//
+//	req := NewHTMLRequest(index)
+//	req.SetFormValue("marginTop", "0")
+//	req.SetFormValue("marginBottom", "0")
+func (req *HTMLRequest) SetFormValue(key, value string) {
+	if req.chromeRequest != nil {
+		req.chromeRequest.values[key] = value
+	}
+}


### PR DESCRIPTION
Currently, there is no option to set custom values for the HTMLRequest. Hence, it is not possible to remove the default margins on Gotenberg.

By adding this function, we can do things like:

req.SetFormValue("marginTop", "0") to remove the top margin